### PR TITLE
Normalize Telegram usernames and show avatar

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useEffect, useState } from 'react';
+import { getUser, sanitizeTelegramUsername } from '@/lib/tg';
 
 /* ===== Иконки ===== */
 function IconPlus() {
@@ -62,16 +63,55 @@ function Action({
   );
 }
 
+const DEFAULT_AVATAR = '/apple-touch-icon.png';
+const DEFAULT_USERNAME = sanitizeTelegramUsername(undefined);
+
 export default function HomePage() {
   const [hide, setHide] = useState(false);
-  const [user, setUser] = useState('@mityya_La');
+  const [user, setUser] = useState(DEFAULT_USERNAME);
+  const [photoUrl, setPhotoUrl] = useState<string | null>(null);
 
   useEffect(() => {
     try {
       setHide(localStorage.getItem('hideBalance') === '1');
-      const u = localStorage.getItem('username') || '@mityya_La';
-      setUser(u.startsWith('@') ? u : '@' + u);
     } catch {}
+
+    const tgUser = getUser();
+
+    let storedUsername: string | null = null;
+    let storedPhoto: string | null = null;
+    try {
+      storedUsername = localStorage.getItem('username');
+      storedPhoto = localStorage.getItem('userPhoto') ?? localStorage.getItem('photo_url');
+    } catch {}
+
+    const normalizedUsername = sanitizeTelegramUsername(tgUser?.username ?? storedUsername ?? undefined);
+    setUser(normalizedUsername);
+
+    if (tgUser?.username) {
+      try {
+        localStorage.setItem('username', tgUser.username);
+      } catch {}
+    } else if (storedUsername && normalizedUsername !== DEFAULT_USERNAME) {
+      try {
+        localStorage.setItem('username', normalizedUsername);
+      } catch {}
+    }
+
+    const resolvedPhoto = (() => {
+      const candidate = tgUser?.photo_url ?? storedPhoto ?? null;
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate;
+      }
+      return null;
+    })();
+    setPhotoUrl(resolvedPhoto);
+
+    if (tgUser?.photo_url && resolvedPhoto === tgUser.photo_url) {
+      try {
+        localStorage.setItem('userPhoto', tgUser.photo_url);
+      } catch {}
+    }
   }, []);
 
   const toggle = () =>
@@ -89,6 +129,13 @@ export default function HomePage() {
       <section className="home-hero">
         <div className="hero-top">
           <div className="user-chip">
+            <div className="ava">
+              <img
+                src={photoUrl ?? DEFAULT_AVATAR}
+                alt={user}
+                style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              />
+            </div>
             <div style={{ fontWeight: 800 }}>{user}</div>
           </div>
           <div className="badge-beta">beta ⓘ</div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,9 +1,12 @@
 'use client';
 import React, { useEffect, useState } from 'react';
+import { getUser, sanitizeTelegramUsername } from '@/lib/tg';
 import { tr } from '../../components/ui/tr';
 
+const DEFAULT_USERNAME = sanitizeTelegramUsername(undefined);
+
 export default function ProfilePage(){
-  const [username, setUsername] = useState('@user');
+  const [username, setUsername] = useState(DEFAULT_USERNAME);
   const [email, setEmail] = useState<string|undefined>();
   const [verified, setVerified] = useState(false);
   const [langLabel, setLangLabel] = useState('Русский');
@@ -11,9 +14,17 @@ export default function ProfilePage(){
   const [walletsCount, setWalletsCount] = useState<number>(0);
 
   useEffect(()=>{
+    const tgUser = getUser();
+    setUsername(sanitizeTelegramUsername(tgUser?.username ?? undefined));
     try{
-      const u = localStorage.getItem('username') || '@user';
-      setUsername(u.startsWith('@') ? u : '@'+u);
+      const storedUsername = localStorage.getItem('username');
+      const normalized = sanitizeTelegramUsername(tgUser?.username ?? storedUsername ?? undefined);
+      setUsername(normalized);
+      if (tgUser?.username){
+        localStorage.setItem('username', tgUser.username);
+      } else if (storedUsername && normalized !== DEFAULT_USERNAME){
+        localStorage.setItem('username', normalized);
+      }
       const m = localStorage.getItem('userEmail') || undefined;
       setEmail(m);
       setVerified(localStorage.getItem('userEmailVerified')==='1');

--- a/lib/tg.ts
+++ b/lib/tg.ts
@@ -1,4 +1,30 @@
 export type TGUser = { id:number; username?:string; first_name?:string; last_name?:string; photo_url?:string; };
+
+const TELEGRAM_USERNAME_REGEX = /^[a-z][a-z0-9_]{4,31}$/;
+
+function normalizeCandidate(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const withoutAt = trimmed.replace(/^@+/, '');
+  const onlySafeChars = withoutAt.replace(/[^0-9a-z_]/gi, '');
+  if (!onlySafeChars) return null;
+  const truncated = onlySafeChars.slice(0, 32);
+  if (!TELEGRAM_USERNAME_REGEX.test(truncated.toLowerCase())) return null;
+  return truncated;
+}
+
+function resolveFallback(fallback: unknown): string {
+  const normalized = normalizeCandidate(fallback) ?? 'unknown';
+  return `@${normalized}`;
+}
+
+export function sanitizeTelegramUsername(value: unknown, fallback: unknown = '@unknown'): string {
+  const fallbackHandle = resolveFallback(fallback);
+  const normalized = normalizeCandidate(value);
+  return normalized ? `@${normalized}` : fallbackHandle;
+}
+
 export function getTG(){ return (typeof window!=='undefined') ? (window as any).Telegram?.WebApp : undefined; }
 export function getUser(): TGUser | null {
   const tg = getTG();


### PR DESCRIPTION
## Summary
- add a reusable sanitizeTelegramUsername helper that strips invalid characters and guarantees a safe fallback
- normalize Telegram user data on the home screen, persist a cleaned username, and show the avatar or a placeholder
- reuse the sanitizer on the profile page so both views display the same cleaned handle

## Testing
- npm run lint *(fails: prompts for ESLint configuration and aborts)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a016fba88326b0abedef2d93557c