### PR TITLE
Implement localized i18n support

### DIFF
--- a/app/actions/topup/page.tsx
+++ b/app/actions/topup/page.tsx
@@ -1,9 +1,12 @@
 'use client';
+import { useI18n } from '../../../lib/i18n';
+
 export default function Top_upPage(){
+  const { t } = useI18n();
   return (
     <div style={{padding:16}}>
-      <h1 style={{margin:0}}>Пополнить</h1>
-      <p>Каркас страницы <code>actions/topup</code></p>
+      <h1 style={{margin:0}}>{t('topup','title')}</h1>
+      <p>{t('topup','demo_note')}</p>
     </div>
   );
 }

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useEffect, useState } from 'react';
+import { useI18n } from '../../lib/i18n';
 
 /* ===== Иконки ===== */
 function IconPlus() {
@@ -63,6 +64,7 @@ function Action({
 }
 
 export default function HomePage() {
+  const { t } = useI18n();
   const [hide, setHide] = useState(false);
   const [user, setUser] = useState('@mityya_La');
 
@@ -91,7 +93,7 @@ export default function HomePage() {
           <div className="user-chip">
             <div style={{ fontWeight: 800 }}>{user}</div>
           </div>
-          <div className="badge-beta">beta ⓘ</div>
+          <div className="badge-beta">{t('common', 'beta_badge')}</div>
         </div>
 
         <div style={{ marginTop: 10 }}>
@@ -100,27 +102,27 @@ export default function HomePage() {
 
         <div className="hero-balance">
           <h2>
-            Общий баланс{' '}
+            {t('home', 'total_balance')}{' '}
             <button onClick={toggle} className="btn btn-ghost" style={{ marginLeft: 6 }}>
               👁
             </button>
           </h2>
-          <div className="hero-amount">{hide ? '• • • ₽' : '0.0 ₽'}</div>
+          <div className="hero-amount">{hide ? t('home', 'hidden_amount') : '0.0 ₽'}</div>
         </div>
 
         {/* Quick actions */}
-        <div className="quick-grid" aria-label="Quick actions">
-          <Action href="/topup" icon={<IconPlus />} label="Пополнить" />
-          <Action href="/send" icon={<IconArrow />} label="Отправить" />
-          <Action href="/exchange" icon={<IconBank />} label="Обмен валют" dot />
-          <Action href="/pay" icon={<IconBasket />} label="Оплата" />
+        <div className="quick-grid" aria-label={t('home', 'quick_actions_aria')}>
+          <Action href="/topup" icon={<IconPlus />} label={t('home', 'action_deposit')} />
+          <Action href="/send" icon={<IconArrow />} label={t('home', 'action_send')} />
+          <Action href="/exchange" icon={<IconBank />} label={t('home', 'action_exchange')} dot />
+          <Action href="/pay" icon={<IconBasket />} label={t('home', 'action_pay')} />
         </div>
       </section>
 
       {/* PROMO */}
       <section className="promo-card">
-        <div className="promo-title">До 30% комиссии</div>
-        {/* ...дальше твой контент... */}
+        <div className="promo-title">{t('home', 'promo_title')}</div>
+        <div className="promo-sub">{t('home', 'promo_sub')}</div>
       </section>
     </div>
   );

--- a/app/kyc/page.tsx
+++ b/app/kyc/page.tsx
@@ -1,18 +1,19 @@
 'use client';
 import React from 'react';
-import { tr } from '../../components/ui/tr';
+import { useI18n } from '../../lib/i18n';
 
 export default function KycHub(){
+  const { t } = useI18n();
   return (
     <div className="container" style={{maxWidth:480, margin:'16px auto 96px', padding:'0 16px'}}>
       <section className="card" style={{display:'grid', gap:12, padding:'16px'}}>
-        <h1 style={{margin:0, fontSize:18, fontWeight:900}}>{tr('kyc','title','KYC верификация')}</h1>
-        <p className="meta" style={{margin:'0 0 4px'}}>{tr('kyc','subtitle','Выберите документ и загрузите фото')}</p>
+        <h1 style={{margin:0, fontSize:18, fontWeight:900}}>{t('kyc','title')}</h1>
+        <p className="meta" style={{margin:'0 0 4px'}}>{t('kyc','subtitle')}</p>
 
         <div className="kyc-list">
-          <KycTile href="/kyc/passport" label={tr('kyc','passport','Паспорт')}            icon={<IconDoc/>}/>
-          <KycTile href="/kyc/id"       label={tr('kyc','idcard','ID-карта')}             icon={<IconId/>}/>
-          <KycTile href="/kyc/driver"   label={tr('kyc','driver','Водительское удостоверение')} icon={<IconDriver/>}/>
+          <KycTile href="/kyc/passport" label={t('kyc','passport')}            icon={<IconDoc/>}/>
+          <KycTile href="/kyc/id"       label={t('kyc','idcard')}             icon={<IconId/>}/>
+          <KycTile href="/kyc/driver"   label={t('kyc','driver')} icon={<IconDriver/>}/>
         </div>
       </section>
     </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,10 +1,13 @@
 'use client';
 import React, { useEffect, useState } from 'react';
+import { getUser, sanitizeTelegramUsername } from '@/lib/tg';
 import { useI18n } from '../../lib/i18n';
+
+const DEFAULT_USERNAME = sanitizeTelegramUsername(undefined);
 
 export default function ProfilePage(){
   const { t, lang: activeLang } = useI18n();
-  const [username, setUsername] = useState('@user');
+  const [username, setUsername] = useState(DEFAULT_USERNAME);
   const [email, setEmail] = useState<string|undefined>();
   const [verified, setVerified] = useState(false);
   const [devicesCount, setDevicesCount] = useState<number>(0);
@@ -12,9 +15,17 @@ export default function ProfilePage(){
   const langLabel = t('lang', activeLang) || activeLang;
 
   useEffect(()=>{
+    const tgUser = getUser();
+    setUsername(sanitizeTelegramUsername(tgUser?.username ?? undefined));
     try{
-      const u = localStorage.getItem('username') || '@user';
-      setUsername(u.startsWith('@') ? u : '@'+u);
+      const storedUsername = localStorage.getItem('username');
+      const normalized = sanitizeTelegramUsername(tgUser?.username ?? storedUsername ?? undefined);
+      setUsername(normalized);
+      if (tgUser?.username){
+        localStorage.setItem('username', tgUser.username);
+      } else if (storedUsername && normalized !== DEFAULT_USERNAME){
+        localStorage.setItem('username', normalized);
+      }
       const m = localStorage.getItem('userEmail') || undefined;
       setEmail(m);
       setVerified(localStorage.getItem('userEmailVerified')==='1');

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,14 +1,15 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import { tr } from '../../components/ui/tr';
+import { useI18n } from '../../lib/i18n';
 
 export default function ProfilePage(){
+  const { t, lang: activeLang } = useI18n();
   const [username, setUsername] = useState('@user');
   const [email, setEmail] = useState<string|undefined>();
   const [verified, setVerified] = useState(false);
-  const [langLabel, setLangLabel] = useState('Русский');
   const [devicesCount, setDevicesCount] = useState<number>(0);
   const [walletsCount, setWalletsCount] = useState<number>(0);
+  const langLabel = t('lang', activeLang) || activeLang;
 
   useEffect(()=>{
     try{
@@ -17,8 +18,6 @@ export default function ProfilePage(){
       const m = localStorage.getItem('userEmail') || undefined;
       setEmail(m);
       setVerified(localStorage.getItem('userEmailVerified')==='1');
-      const L = (localStorage.getItem('lang')||'ru').toLowerCase();
-      setLangLabel(L==='en'?'English':L==='id'?'Bahasa Indonesia':'Русский');
       const rawDev = localStorage.getItem('devices_v1');
       if (rawDev){ try{ const arr = JSON.parse(rawDev); setDevicesCount(Array.isArray(arr)?arr.length:0); }catch{} }
       const rawWal = localStorage.getItem('wallets.v1');
@@ -50,8 +49,8 @@ export default function ProfilePage(){
         <a href="/kyc" className="mini-tile">
           <span className="mini-ico">{IconShield()}</span>
           <div className="mini-col">
-            <div className="mini-title">{tr('profile','kyc','KYC верификация')}</div>
-            <div className="mini-sub">{tr('profile','kyc','KYC')}</div>
+            <div className="mini-title">{t('profile','kyc_title')}</div>
+            <div className="mini-sub">{t('profile','kyc_short')}</div>
           </div>
           <span className="chev">›</span>
         </a>
@@ -59,38 +58,40 @@ export default function ProfilePage(){
         <a href="/email" className="mini-tile">
           <span className="mini-ico">{IconAt()}</span>
           <div className="mini-col">
-            <div className="mini-title">{tr('profile','email','E-mail')}</div>
+            <div className="mini-title">{t('profile','email')}</div>
             <div className="mini-sub">
-              {email ? (verified ? tr('profile','email_ok','Подтверждён') : tr('profile','email_verify','Подтвердить')) : tr('profile','email_add','Добавить')}
+              {email
+                ? (verified ? t('profile','email_ok') : t('profile','email_verify'))
+                : t('profile','email_add')}
             </div>
           </div>
           <span className="chev">›</span>
         </a>
       </section>
 
-      <h2 className="sect-title">{tr('profile','ref','Реферальная программа')}</h2>
+      <h2 className="sect-title">{t('profile','ref')}</h2>
       <div className="list-card">
-        <Row href="/promo/ref" icon={IconUsers()} label={tr('profile','ref','Реферальная программа')} />
-        <Row href="/promo"     icon={IconGift()}  label="Promo / Coupons" />
+        <Row href="/promo/ref" icon={IconUsers()} label={t('profile','ref')} />
+        <Row href="/promo"     icon={IconGift()}  label={t('profile','promo')} />
       </div>
 
-      <h2 className="sect-title">{tr('profile','settings','Параметры')}</h2>
+      <h2 className="sect-title">{t('profile','settings')}</h2>
       <div className="list-card">
-        <Row href="/settings/security" icon={IconLock()}    label={tr('security','title','Безопасность')} />
-        <Row href="/settings/language" icon={IconGlobe()}   label={tr('profile','language','Язык')} value={langLabel}/>
-        <Row href="/wallets"           icon={IconWallet()}  label={tr('profile','wallets','Кошельки')} value={String(walletsCount || 0)} />
-        <Row href="/devices"           icon={IconDevice()}  label={tr('profile','devices','Устройства')} value={String(devicesCount || 0)} />
+        <Row href="/settings/security" icon={IconLock()}    label={t('security','title')} />
+        <Row href="/settings/language" icon={IconGlobe()}   label={t('profile','language')} value={langLabel}/>
+        <Row href="/wallets"           icon={IconWallet()}  label={t('profile','wallets')} value={String(walletsCount || 0)} />
+        <Row href="/devices"           icon={IconDevice()}  label={t('profile','devices')} value={String(devicesCount || 0)} />
       </div>
 
-      <h2 className="sect-title">{tr('profile','about','О нас')}</h2>
+      <h2 className="sect-title">{t('profile','about')}</h2>
       <div className="list-card">
-        <Row href="/official" icon={IconTg()}  label="Official accounts" />
-        <Row href="/faq"      icon={IconHelp()} label="FAQ" />
-        <Row href="/info"     icon={IconInfo()} label="Info" />
-        <Row href="/support"  icon={IconChat()} label="Поддержка" />
+        <Row href="/official" icon={IconTg()}  label={t('profile','official_accounts')} />
+        <Row href="/faq"      icon={IconHelp()} label={t('profile','faq')} />
+        <Row href="/info"     icon={IconInfo()} label={t('profile','info')} />
+        <Row href="/support"  icon={IconChat()} label={t('profile','support')} />
       </div>
 
-      <button type="button" onClick={logout} className="logout-btn">{tr('profile','logout','Выйти из аккаунта')}</button>
+      <button type="button" onClick={logout} className="logout-btn">{t('profile','logout')}</button>
     </div>
   );
 }

--- a/app/settings/language/page.tsx
+++ b/app/settings/language/page.tsx
@@ -2,24 +2,45 @@
 import React from 'react';
 import Container from '../../../components/ui/Container';
 import { Card, CardBody } from '../../../components/ui/Card';
+import { useI18n } from '../../../lib/i18n';
+import { AVAILABLE_LANGS } from '../../../lib/locale';
 
 export default function LanguagePage() {
+  const { lang, setLang, t } = useI18n();
   return (
     <main className="py-4">
       <Container>
-        <h1 className="text-2xl font-semibold mb-4">Язык</h1>
-        <Card>
-          <CardBody className="flex items-center justify-between">
-            <div>
-              <div className="font-medium">Русский</div>
-              <div className="text-sm text-gray-500">Текущий язык приложения</div>
-            </div>
-            <div className="w-6 h-6 rounded-full border bg-black border-black text-white">
-              <span className="block text-center leading-6">✓</span>
-            </div>
-          </CardBody>
-        </Card>
-        <p className="text-xs text-gray-500 mt-3">Другие языки отключены.</p>
+        <h1 className="text-2xl font-semibold mb-4">{t('settings','language_title')}</h1>
+        <div className="space-y-2">
+          {AVAILABLE_LANGS.map((code) => {
+            const selected = lang === code;
+            return (
+              <Card key={code}>
+                <button
+                  type="button"
+                  onClick={() => setLang(code)}
+                  className="w-full text-left"
+                  aria-pressed={selected}
+                >
+                  <CardBody className="flex items-center justify-between">
+                    <div>
+                      <div className="font-medium">{t('lang', code)}</div>
+                      {selected && (
+                        <div className="text-sm text-gray-500">{t('settings','language_current')}</div>
+                      )}
+                    </div>
+                    {selected && (
+                      <div className="w-6 h-6 rounded-full border bg-black border-black text-white">
+                        <span className="block text-center leading-6">✓</span>
+                      </div>
+                    )}
+                  </CardBody>
+                </button>
+              </Card>
+            );
+          })}
+        </div>
+        <p className="text-xs text-gray-500 mt-3">{t('settings','language_hint')}</p>
       </Container>
     </main>
   );

--- a/app/settings/language/page.v2.tsx
+++ b/app/settings/language/page.v2.tsx
@@ -12,7 +12,7 @@ export default function LanguagePage() {
   const { lang, setLang, t } = useI18n();
   return (
     <main className="mx-auto max-w-[480px] p-4">
-      <h1 className="text-xl font-semibold mb-4">{t('settings.language.title')}</h1>
+      <h1 className="text-xl font-semibold mb-4">{t('settings','language_title')}</h1>
       <div className="space-y-2">
         {LANGS.map(L => (
           <button

--- a/app/settings/security/page.tsx
+++ b/app/settings/security/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import { tr } from '../../../components/ui/tr';
+import { useI18n } from '../../../lib/i18n';
 
 export default function SecurityPage(){
+  const { t } = useI18n();
   const [email,setEmail] = useState<string|undefined>();
   const [verified,setVerified] = useState(false);
   const [pin,setPin] = useState(false);
@@ -21,28 +22,28 @@ export default function SecurityPage(){
 
   return (
     <div style={{maxWidth:480, margin:'0 auto 96px', padding:'12px 16px'}}>
-      <h1 className="sect-title" style={{marginTop:4}}>{tr('security','title','Безопасность')}</h1>
+      <h1 className="sect-title" style={{marginTop:4}}>{t('security','title')}</h1>
       <div className="list-card">
         <div className="list-row">
           <span className="row-ico">{IconMail()}</span>
-          <span className="row-label">{tr('profile','email','E-mail')}</span>
+          <span className="row-label">{t('profile','email')}</span>
           <span className="row-value" style={{marginLeft:'auto'}}>{
-            email ? (verified ? tr('profile','email_ok','Подтверждён') : tr('profile','email_verify','Подтвердить')) : tr('profile','email_add','Добавить')
+            email ? (verified ? t('profile','email_ok') : t('profile','email_verify')) : t('profile','email_add')
           }</span>
         </div>
       </div>
 
-      <h2 className="sect-title">{tr('security','subtitle','E-mail, PIN, приватность')}</h2>
+      <h2 className="sect-title">{t('security','subtitle')}</h2>
       <div className="list-card">
         <div className="list-row">
           <span className="row-ico">{IconPin()}</span>
-          <span className="row-label">{pin?tr('security','pin_on','PIN: включён'):tr('security','pin_off','PIN: выключен')}</span>
-          <button className="row-pill" data-on={pin?1:0} onClick={toggle('pin_enabled', setPin)}>{tr('security','toggle_pin','Переключить PIN')}</button>
+          <span className="row-label">{pin ? t('security','pin_on') : t('security','pin_off')}</span>
+          <button className="row-pill" data-on={pin?1:0} onClick={toggle('pin_enabled', setPin)}>{t('security','toggle_pin')}</button>
         </div>
         <div className="list-row">
           <span className="row-ico">{IconEye()}</span>
-          <span className="row-label">{hide?tr('security','hide_on','Скрывать баланс: да'):tr('security','hide_off','Скрывать баланс: нет')}</span>
-          <button className="row-pill" data-on={hide?1:0} onClick={toggle('hideBalance', setHide)}>{tr('security','toggle_hide','Скрывать баланс')}</button>
+          <span className="row-label">{hide ? t('security','hide_on') : t('security','hide_off')}</span>
+          <button className="row-pill" data-on={hide?1:0} onClick={toggle('hideBalance', setHide)}>{t('security','toggle_hide')}</button>
         </div>
       </div>
     </div>

--- a/app/topup/page.tsx
+++ b/app/topup/page.tsx
@@ -1,29 +1,30 @@
 'use client';
 import React, { useState } from 'react';
-import { tr } from '../../components/ui/tr';
+import { useI18n } from '../../lib/i18n';
 
 const TABS = ['IDR','RUB','USD','EUR'] as const;
 type Cur = typeof TABS[number];
 
 export default function TopUpPage(){
+  const { t } = useI18n();
   const [cur, setCur] = useState<Cur>('RUB');
 
   return (
     <div className="container" style={{maxWidth:480, margin:'90px auto 96px', padding:'0 16px', display:'grid', gap:12}}>
       <section className="card" style={{display:'grid', gap:10}}>
-        <h1 style={{fontSize:18, fontWeight:800, margin:0}}>{tr('topup','title','Пополнить')}</h1>
+        <h1 style={{fontSize:18, fontWeight:800, margin:0}}>{t('topup','title')}</h1>
         <div className="seg">{TABS.map(t=><button key={t} data-active={cur===t?1:0} onClick={()=>setCur(t)}>{t}</button>)}</div>
-        <div className="field"><input placeholder={`${tr('topup','amount_in','Сумма в')} ${cur}`} inputMode="decimal" /><span className="meta">{tr('topup','currency','валюта')}</span></div>
-        <p className="meta" style={{margin:0}}>{tr('topup','demo_note','Это демо-экран. Функции пополнения — визуал без бэкенда.')}</p>
+        <div className="field"><input placeholder={`${t('topup','amount_in')} ${cur}`} inputMode="decimal" /><span className="meta">{t('topup','currency')}</span></div>
+        <p className="meta" style={{margin:0}}>{t('topup','demo_note')}</p>
       </section>
 
       <section className="card" style={{display:'grid', gap:10}}>
-        <h2 style={{fontSize:16, fontWeight:800, margin:0}}>{tr('topup','methods','Способы')}</h2>
-        <Method href="/wallets" icon={<IconCard/>} title={tr('topup','card','Банковская карта')} note={tr('topup','card_note','UI-демо, без списания')} />
-        <Method href="/wallets" icon={<IconCrypto/>} title={tr('topup','crypto','Крипто-депозит')} note={tr('topup','crypto_note','Пополнение через адрес')} />
-        <Method href="/scan"    icon={<IconQR/>}    title={tr('topup','qr','QR-код')}          note={tr('topup','qr_note','Отсканировать код для оплаты')} />
-        <Method href="/promo"   icon={<IconGift/>}  title={tr('topup','gift','Подарочный код')} note={tr('topup','gift_note','Активировать промокод')} />
-        <a href="/home" className="btn" style={{width:'100%'}}>{tr('topup','done','Готово')}</a>
+        <h2 style={{fontSize:16, fontWeight:800, margin:0}}>{t('topup','methods')}</h2>
+        <Method href="/wallets" icon={<IconCard/>} title={t('topup','card')} note={t('topup','card_note')} />
+        <Method href="/wallets" icon={<IconCrypto/>} title={t('topup','crypto')} note={t('topup','crypto_note')} />
+        <Method href="/scan"    icon={<IconQR/>}    title={t('topup','qr')}          note={t('topup','qr_note')} />
+        <Method href="/promo"   icon={<IconGift/>}  title={t('topup','gift')} note={t('topup','gift_note')} />
+        <a href="/home" className="btn" style={{width:'100%'}}>{t('topup','done')}</a>
       </section>
     </div>
   );

--- a/components/providers/I18nProvider.tsx
+++ b/components/providers/I18nProvider.tsx
@@ -1,0 +1,4 @@
+'use client';
+
+export { I18nProvider as default, useI18n, t } from '../../lib/i18n';
+export type { Lang } from '../../lib/locale';

--- a/components/ui/ActionGrid.tsx
+++ b/components/ui/ActionGrid.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React from 'react';
+import { useI18n } from '../../lib/i18n';
 
 export type Tile = {
   href: string;
@@ -19,6 +20,7 @@ export default function ActionGrid({items}:{items: Tile[]}) {
 }
 
 function Tile({href,label,icon,badge,ok,disabled}:Tile){
+  const { t } = useI18n();
   const body = (
     <div className={`tile ${disabled?'is-disabled':''}`}>
       <div className="tile-ico">{icon ?? <span className="dot"/>}</div>
@@ -27,7 +29,7 @@ function Tile({href,label,icon,badge,ok,disabled}:Tile){
         {badge && <span className="tile-badge">{badge}</span>}
       </div>
       {ok && <span className="tile-ok">✓</span>}
-      {disabled && <span className="tile-soon">Soon</span>}
+      {disabled && <span className="tile-soon">{t('common','soon')}</span>}
     </div>
   );
   return disabled ? <div className="tile-wrap">{body}</div> : <Link className="tile-wrap" href={href}>{body}</a>;

--- a/components/ui/tr.ts
+++ b/components/ui/tr.ts
@@ -1,4 +1,9 @@
-/** RU-only: всегда отдаём переданный fallback (русский). */
-export function tr(_ns: string, _key: string, fallback?: string){
-  return (fallback ?? _key);
+import { t as translate } from '../../lib/i18n';
+
+export function tr(ns: string, key: string, fallback?: string) {
+  const value = translate(ns, key);
+  if (value === key && fallback !== undefined) {
+    return fallback;
+  }
+  return value;
 }

--- a/lib/dictionaries/en.ts
+++ b/lib/dictionaries/en.ts
@@ -1,11 +1,3 @@
-export const en = {
-  'home.balance': 'Total balance',
-  'quick.deposit': 'Deposit',
-  'quick.send': 'Send',
-  'quick.exchange': 'Exchange',
-  'quick.pay': 'Pay',
-  'commission.up_to_30': 'Up to 30% commission',
-  'invite': 'Invite',
-  'settings.language.title': 'Language',
-  'settings.security.title': 'Security',
-};
+import { dictionaries } from '../locale';
+
+export const en = dictionaries.en;

--- a/lib/dictionaries/id.ts
+++ b/lib/dictionaries/id.ts
@@ -1,11 +1,3 @@
-export const id = {
-  'home.balance': 'Saldo total',
-  'quick.deposit': 'Isi ulang',
-  'quick.send': 'Kirim',
-  'quick.exchange': 'Tukar',
-  'quick.pay': 'Pembayaran',
-  'commission.up_to_30': 'Hingga 30% komisi',
-  'invite': 'Undang',
-  'settings.language.title': 'Bahasa',
-  'settings.security.title': 'Keamanan',
-};
+import { dictionaries } from '../locale';
+
+export const id = dictionaries.id;

--- a/lib/dictionaries/ru.ts
+++ b/lib/dictionaries/ru.ts
@@ -1,11 +1,3 @@
-export const ru = {
-  'home.balance': 'Общий баланс',
-  'quick.deposit': 'Пополнить',
-  'quick.send': 'Отправить',
-  'quick.exchange': 'Обмен валют',
-  'quick.pay': 'Оплата',
-  'commission.up_to_30': 'До 30% комиссии',
-  'invite': 'Пригласить',
-  'settings.language.title': 'Язык',
-  'settings.security.title': 'Безопасность',
-};
+import { dictionaries } from '../locale';
+
+export const ru = dictionaries.ru;

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1,51 +1,194 @@
-// @ts-nocheck
 'use client';
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
-export type Lang = 'ru' | 'en' | 'id';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  FALLBACK_LANG,
+  LANG_STORAGE_KEY,
+  dictionaries,
+  normalizeLang,
+  type Lang,
+  type Namespace,
+} from './locale';
+
+type TranslateVars = Record<string, string | number>;
+
+type TranslateFn = (ns: string, key: string, vars?: TranslateVars) => string;
 
 type I18nCtx = {
   lang: Lang;
-  t: (key: string, vars?: Record<string, unknown>) => string;
-  setLang: (l: Lang) => void; // ← гарантированно есть
+  t: TranslateFn;
+  setLang: (lang: Lang) => void;
 };
 
-// Дефолт: русский, заглушка t, setLang-нооп (чтобы не падало до маунта)
+const STORAGE_KEY = LANG_STORAGE_KEY;
+
 const Ctx = createContext<I18nCtx>({
-  lang: 'ru',
-  t: (key) => key,
+  lang: FALLBACK_LANG,
+  t: (_ns, key) => key,
   setLang: () => {},
 });
 
+let runtimeLang: Lang = FALLBACK_LANG;
+
+type InitialResolution = {
+  lang: Lang;
+  fromStorage: boolean;
+};
+
+function applyVars(template: string, vars?: TranslateVars) {
+  if (!vars) return template;
+  return template.replace(/\{(\w+)\}/g, (match, token) =>
+    Object.prototype.hasOwnProperty.call(vars, token) ? String(vars[token]) : match,
+  );
+}
+
+function resolveTemplate(lang: Lang, ns: string, key: string) {
+  const namespace = dictionaries[lang]?.[ns as Namespace];
+  return namespace?.[key];
+}
+
+function translateWith(lang: Lang, ns: string, key: string, vars?: TranslateVars) {
+  const template =
+    resolveTemplate(lang, ns, key) ??
+    (lang !== FALLBACK_LANG ? resolveTemplate(FALLBACK_LANG, ns, key) : undefined) ??
+    key;
+  return applyVars(template, vars);
+}
+
+function readLangFromStorage(): Lang | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return normalizeLang(raw);
+  } catch {
+    return null;
+  }
+}
+
+function detectBrowserLang(): Lang | null {
+  if (typeof navigator === 'undefined') return null;
+  const candidates: Array<string | undefined> = Array.isArray(navigator.languages)
+    ? navigator.languages
+    : [navigator.language];
+
+  for (const raw of candidates) {
+    if (!raw) continue;
+    const normalized = normalizeLang(raw);
+    if (normalized) return normalized;
+    const base = raw.split?.('-')?.[0];
+    const short = base && base !== raw ? normalizeLang(base) : null;
+    if (short) return short;
+  }
+  return null;
+}
+
+function resolveInitialLang(initialLang: Lang): InitialResolution {
+  if (typeof window === 'undefined') {
+    return { lang: initialLang, fromStorage: false };
+  }
+  const stored = readLangFromStorage();
+  if (stored) {
+    return { lang: stored, fromStorage: true };
+  }
+  const browser = detectBrowserLang();
+  if (browser) {
+    return { lang: browser, fromStorage: false };
+  }
+  return { lang: initialLang, fromStorage: false };
+}
+
+function persistLang(lang: Lang) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, lang);
+  } catch {}
+}
+
+function updateRuntimeLang(lang: Lang) {
+  runtimeLang = lang;
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('i18n:changed', { detail: lang }));
+  }
+}
+
 export function I18nProvider({
   children,
-  initialLang = 'ru',
+  initialLang = FALLBACK_LANG,
 }: {
   children: React.ReactNode;
   initialLang?: Lang;
 }) {
-  const [lang, setLangState] = useState<Lang>(initialLang);
+  const initialRef = useRef<InitialResolution>();
+  if (!initialRef.current) {
+    initialRef.current = resolveInitialLang(initialLang);
+    runtimeLang = initialRef.current.lang;
+  }
 
-  // берём язык из localStorage при маунте (если есть)
+  const [lang, setLangState] = useState<Lang>(initialRef.current.lang);
+  const langRef = useRef(lang);
+
   useEffect(() => {
-    try {
-      const saved = localStorage.getItem('lang') as Lang | null;
-      if (saved) setLangState(saved);
-    } catch {}
+    langRef.current = lang;
+  }, [lang]);
+
+  useEffect(() => {
+    updateRuntimeLang(langRef.current);
+    if (!initialRef.current?.fromStorage) {
+      persistLang(langRef.current);
+      initialRef.current = { lang: langRef.current, fromStorage: true };
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const setLang = (l: Lang) => {
-    setLangState(l);
-    try { localStorage.setItem('lang', l); } catch {}
-  };
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== STORAGE_KEY) return;
+      const next = normalizeLang(event.newValue);
+      if (next && next !== langRef.current) {
+        langRef.current = next;
+        updateRuntimeLang(next);
+        setLangState(next);
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
 
-  const t = (key: string) => key; // простая заглушка
+  const setLang = useCallback((next: Lang) => {
+    setLangState((prev) => {
+      if (prev === next) return prev;
+      langRef.current = next;
+      persistLang(next);
+      updateRuntimeLang(next);
+      return next;
+    });
+  }, []);
 
-  const value = useMemo(() => ({ lang, t, setLang }), [lang]);
+  const translate = useCallback<TranslateFn>(
+    (ns, key, vars) => translateWith(langRef.current, ns, key, vars),
+    [],
+  );
+
+  const value = useMemo<I18nCtx>(
+    () => ({ lang, setLang, t: translate }),
+    [lang, setLang, translate],
+  );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }
 
 export function useI18n() {
   return useContext(Ctx);
+}
+
+export function t(ns: string, key: string, vars?: TranslateVars) {
+  return translateWith(runtimeLang, ns, key, vars);
 }

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -1,46 +1,283 @@
-export type Lang = 'ru' | 'en' | 'id';
+export const AVAILABLE_LANGS = ['ru', 'en', 'id'] as const;
+export type Lang = (typeof AVAILABLE_LANGS)[number];
 
-const dict: Record<Lang, Record<string, Record<string, string>>> = {
+export type Namespace =
+  | 'common'
+  | 'home'
+  | 'profile'
+  | 'security'
+  | 'lang'
+  | 'settings'
+  | 'kyc'
+  | 'topup';
+
+export type Messages = Record<Namespace, Record<string, string>>;
+
+export const FALLBACK_LANG: Lang = 'ru';
+export const LANG_STORAGE_KEY = 'lang';
+
+export const dictionaries: Record<Lang, Messages> = {
   ru: {
-    quick: { topup:'Пополнить', send:'Отправить', exchange:'Обмен валют', pay:'Оплата', aria:'Быстрые действия' },
-    home: { total_balance:'Общий баланс', toggle_balance:'Показать/скрыть баланс', hidden_amount:'• • • ₽', quick_actions:'Быстрые действия', action_topup:'Пополнить', action_send:'Отправить', action_sell:'Обмен', action_pay:'Оплата', promo_title:'До 30% комиссии', promo_sub:'за платежи друзей по вашей ссылке', promo_cta:'Пригласить', soon:'Скоро', asset_badge_new:'NEW' },
-    profile:{ title:'Профиль', ref:'Реферальная программа', settings:'Параметры', about:'О нас', kyc:'KYC верификация', email:'E-mail', email_add:'Добавить', email_verify:'Подтвердить', email_ok:'Подтверждён', wallets:'Кошельки', devices:'Устройства', language:'Язык', logout:'Выйти из аккаунта' },
-    security:{ title:'Безопасность', subtitle:'E-mail, PIN, приватность', pin_on:'PIN: включён', pin_off:'PIN: выключен', hide_on:'Скрывать баланс: да', hide_off:'Скрывать баланс: нет', toggle_pin:'Переключить PIN', toggle_hide:'Скрывать баланс' },
-    lang:{ title:'Язык', ru:'Русский', en:'English', id:'Bahasa Indonesia' }
+    common: {
+      beta_badge: 'beta ⓘ',
+      soon: 'Скоро',
+    },
+    home: {
+      total_balance: 'Общий баланс',
+      toggle_balance: 'Показать/скрыть баланс',
+      hidden_amount: '• • • ₽',
+      quick_actions: 'Быстрые действия',
+      quick_actions_aria: 'Быстрые действия',
+      action_deposit: 'Пополнить',
+      action_send: 'Отправить',
+      action_exchange: 'Обмен валют',
+      action_pay: 'Оплата',
+      promo_title: 'До 30% комиссии',
+      promo_sub: 'за платежи друзей по вашей ссылке',
+      promo_cta: 'Пригласить',
+    },
+    profile: {
+      title: 'Профиль',
+      ref: 'Реферальная программа',
+      settings: 'Параметры',
+      about: 'О нас',
+      kyc_title: 'KYC верификация',
+      kyc_short: 'KYC',
+      email: 'E-mail',
+      email_add: 'Добавить',
+      email_verify: 'Подтвердить',
+      email_ok: 'Подтверждён',
+      wallets: 'Кошельки',
+      devices: 'Устройства',
+      language: 'Язык',
+      logout: 'Выйти из аккаунта',
+      promo: 'Промо и купоны',
+      official_accounts: 'Официальные аккаунты',
+      faq: 'FAQ',
+      info: 'Инфо',
+      support: 'Поддержка',
+    },
+    security: {
+      title: 'Безопасность',
+      subtitle: 'E-mail, PIN, приватность',
+      pin_on: 'PIN: включён',
+      pin_off: 'PIN: выключен',
+      hide_on: 'Скрывать баланс: да',
+      hide_off: 'Скрывать баланс: нет',
+      toggle_pin: 'Переключить PIN',
+      toggle_hide: 'Скрывать баланс',
+    },
+    lang: {
+      title: 'Язык',
+      ru: 'Русский',
+      en: 'English',
+      id: 'Bahasa Indonesia',
+    },
+    settings: {
+      language_title: 'Язык',
+      language_current: 'Текущий язык приложения',
+      language_hint: 'Выберите язык интерфейса',
+    },
+    kyc: {
+      title: 'KYC верификация',
+      subtitle: 'Выберите документ и загрузите фото',
+      passport: 'Паспорт',
+      idcard: 'ID-карта',
+      driver: 'Водительское удостоверение',
+    },
+    topup: {
+      title: 'Пополнить',
+      amount_in: 'Сумма в',
+      currency: 'валюта',
+      demo_note: 'Это демо-экран. Функции пополнения — визуал без бэкенда.',
+      methods: 'Способы',
+      card: 'Банковская карта',
+      card_note: 'UI-демо, без списания',
+      crypto: 'Крипто-депозит',
+      crypto_note: 'Пополнение через адрес',
+      qr: 'QR-код',
+      qr_note: 'Отсканировать код для оплаты',
+      gift: 'Подарочный код',
+      gift_note: 'Активировать промокод',
+      done: 'Готово',
+    },
   },
   en: {
-    quick: { topup:'Top up', send:'Send', exchange:'Exchange', pay:'Pay', aria:'Quick actions' },
-    home: { total_balance:'Total balance', toggle_balance:'Show/Hide balance', hidden_amount:'• • •', quick_actions:'Quick actions', action_topup:'Top up', action_send:'Send', action_sell:'Exchange', action_pay:'Pay', promo_title:'Up to 30% commission', promo_sub:"from each friend's payment", promo_cta:'Invite', soon:'Soon', asset_badge_new:'NEW' },
-    profile:{ title:'Profile', ref:'Referral program', settings:'Settings', about:'About', kyc:'KYC verification', email:'E-mail', email_add:'Add', email_verify:'Verify', email_ok:'Verified', wallets:'Wallets', devices:'Devices', language:'Language', logout:'Log out' },
-    security:{ title:'Security', subtitle:'E-mail, PIN, privacy', pin_on:'PIN: on', pin_off:'PIN: off', hide_on:'Hide balance: yes', hide_off:'Hide balance: no', toggle_pin:'Toggle PIN', toggle_hide:'Hide balance' },
-    lang:{ title:'Language', ru:'Русский', en:'English', id:'Bahasa Indonesia' }
+    common: {
+      beta_badge: 'beta ⓘ',
+      soon: 'Soon',
+    },
+    home: {
+      total_balance: 'Total balance',
+      toggle_balance: 'Show/Hide balance',
+      hidden_amount: '• • •',
+      quick_actions: 'Quick actions',
+      quick_actions_aria: 'Quick actions',
+      action_deposit: 'Deposit',
+      action_send: 'Send',
+      action_exchange: 'Exchange',
+      action_pay: 'Pay',
+      promo_title: 'Up to 30% commission',
+      promo_sub: "from each friend's payment",
+      promo_cta: 'Invite',
+    },
+    profile: {
+      title: 'Profile',
+      ref: 'Referral program',
+      settings: 'Settings',
+      about: 'About',
+      kyc_title: 'KYC verification',
+      kyc_short: 'KYC',
+      email: 'E-mail',
+      email_add: 'Add',
+      email_verify: 'Verify',
+      email_ok: 'Verified',
+      wallets: 'Wallets',
+      devices: 'Devices',
+      language: 'Language',
+      logout: 'Log out',
+      promo: 'Promo & Coupons',
+      official_accounts: 'Official accounts',
+      faq: 'FAQ',
+      info: 'Info',
+      support: 'Support',
+    },
+    security: {
+      title: 'Security',
+      subtitle: 'E-mail, PIN, privacy',
+      pin_on: 'PIN: on',
+      pin_off: 'PIN: off',
+      hide_on: 'Hide balance: yes',
+      hide_off: 'Hide balance: no',
+      toggle_pin: 'Toggle PIN',
+      toggle_hide: 'Hide balance',
+    },
+    lang: {
+      title: 'Language',
+      ru: 'Russian',
+      en: 'English',
+      id: 'Bahasa Indonesia',
+    },
+    settings: {
+      language_title: 'Language',
+      language_current: 'Current app language',
+      language_hint: 'Choose the app language',
+    },
+    kyc: {
+      title: 'KYC verification',
+      subtitle: 'Choose a document and upload photos',
+      passport: 'Passport',
+      idcard: 'ID card',
+      driver: 'Driver license',
+    },
+    topup: {
+      title: 'Top up',
+      amount_in: 'Amount in',
+      currency: 'currency',
+      demo_note: 'This is a demo screen. Top-up actions are UI only.',
+      methods: 'Methods',
+      card: 'Bank card',
+      card_note: 'UI demo, no charges',
+      crypto: 'Crypto deposit',
+      crypto_note: 'Fund via address',
+      qr: 'QR code',
+      qr_note: 'Scan a code to pay',
+      gift: 'Gift code',
+      gift_note: 'Redeem promo code',
+      done: 'Done',
+    },
   },
   id: {
-    quick: { topup:'Isi ulang', send:'Kirim', exchange:'Tukar', pay:'Bayar', aria:'Aksi cepat' },
-    home: { total_balance:'Saldo total', toggle_balance:'Tampil/sembunyi saldo', hidden_amount:'• • •', quick_actions:'Aksi cepat', action_topup:'Isi ulang', action_send:'Kirim', action_sell:'Tukar', action_pay:'Bayar', promo_title:'Hingga 30% komisi', promo_sub:'dari pembayaran teman Anda', promo_cta:'Undang', soon:'Segera', asset_badge_new:'BARU' },
-    profile:{ title:'Profil', ref:'Program rujukan', settings:'Pengaturan', about:'Tentang', kyc:'Verifikasi KYC', email:'E-mail', email_add:'Tambah', email_verify:'Verifikasi', email_ok:'Terverifikasi', wallets:'Dompet', devices:'Perangkat', language:'Bahasa', logout:'Keluar' },
-    security:{ title:'Keamanan', subtitle:'E-mail, PIN, privasi', pin_on:'PIN: aktif', pin_off:'PIN: nonaktif', hide_on:'Sembunyikan saldo: ya', hide_off:'Sembunyikan saldo: tidak', toggle_pin:'Alihkan PIN', toggle_hide:'Sembunyikan saldo' },
-    lang:{ title:'Bahasa', ru:'Русский', en:'English', id:'Bahasa Indonesia' }
-  }
+    common: {
+      beta_badge: 'beta ⓘ',
+      soon: 'Segera',
+    },
+    home: {
+      total_balance: 'Saldo total',
+      toggle_balance: 'Tampil/sembunyi saldo',
+      hidden_amount: '• • •',
+      quick_actions: 'Aksi cepat',
+      quick_actions_aria: 'Aksi cepat',
+      action_deposit: 'Isi ulang',
+      action_send: 'Kirim',
+      action_exchange: 'Tukar',
+      action_pay: 'Bayar',
+      promo_title: 'Hingga 30% komisi',
+      promo_sub: 'dari pembayaran teman Anda',
+      promo_cta: 'Undang',
+    },
+    profile: {
+      title: 'Profil',
+      ref: 'Program rujukan',
+      settings: 'Pengaturan',
+      about: 'Tentang',
+      kyc_title: 'Verifikasi KYC',
+      kyc_short: 'KYC',
+      email: 'E-mail',
+      email_add: 'Tambah',
+      email_verify: 'Verifikasi',
+      email_ok: 'Terverifikasi',
+      wallets: 'Dompet',
+      devices: 'Perangkat',
+      language: 'Bahasa',
+      logout: 'Keluar dari akun',
+      promo: 'Promo & Kupon',
+      official_accounts: 'Akun resmi',
+      faq: 'FAQ',
+      info: 'Info',
+      support: 'Dukungan',
+    },
+    security: {
+      title: 'Keamanan',
+      subtitle: 'E-mail, PIN, privasi',
+      pin_on: 'PIN: aktif',
+      pin_off: 'PIN: nonaktif',
+      hide_on: 'Sembunyikan saldo: ya',
+      hide_off: 'Sembunyikan saldo: tidak',
+      toggle_pin: 'Alihkan PIN',
+      toggle_hide: 'Sembunyikan saldo',
+    },
+    lang: {
+      title: 'Bahasa',
+      ru: 'Rusia',
+      en: 'Inggris',
+      id: 'Bahasa Indonesia',
+    },
+    settings: {
+      language_title: 'Bahasa',
+      language_current: 'Bahasa aplikasi saat ini',
+      language_hint: 'Pilih bahasa aplikasi',
+    },
+    kyc: {
+      title: 'Verifikasi KYC',
+      subtitle: 'Pilih dokumen dan unggah foto',
+      passport: 'Paspor',
+      idcard: 'KTP',
+      driver: 'SIM',
+    },
+    topup: {
+      title: 'Isi ulang',
+      amount_in: 'Jumlah dalam',
+      currency: 'mata uang',
+      demo_note: 'Ini adalah layar demo. Top-up hanya antarmuka.',
+      methods: 'Metode',
+      card: 'Kartu bank',
+      card_note: 'Demo UI, tanpa penarikan',
+      crypto: 'Deposit kripto',
+      crypto_note: 'Isi melalui alamat',
+      qr: 'Kode QR',
+      qr_note: 'Pindai kode untuk membayar',
+      gift: 'Kode hadiah',
+      gift_note: 'Tukarkan kode promo',
+      done: 'Selesai',
+    },
+  },
 };
 
-export function getLang(): Lang {
-  try {
-    const raw = (typeof window !== 'undefined' && localStorage.getItem('lang')) || 'ru';
-    const v = String(raw).toLowerCase();
-    return (v === 'en' || v === 'id') ? (v as Lang) : 'ru';
-  } catch { return 'ru'; }
-}
-
-export function setLang(l: Lang) {
-  try {
-    localStorage.setItem('lang', l);
-    window.dispatchEvent(new CustomEvent('i18n:changed', { detail: l }));
-  } catch {}
-}
-
-/** t(ns,key): если ключ не найден — возвращаем сам key */
-export function t(ns: string, key: string): string {
-  const l = getLang();
-  return dict[l]?.[ns]?.[key] ?? key;
+export function normalizeLang(value?: string | null): Lang | null {
+  if (!value) return null;
+  const lower = String(value).toLowerCase();
+  return (AVAILABLE_LANGS as readonly string[]).includes(lower)
+    ? (lower as Lang)
+    : null;
 }

--- a/lib/tg.ts
+++ b/lib/tg.ts
@@ -6,3 +6,15 @@ export function getUser(): TGUser | null {
   if (process.env.NEXT_PUBLIC_TG_MOCK === '1') return { id: 777, username: 'mock_user', first_name: 'Mock', last_name: 'User' };
   return null;
 }
+
+const DEFAULT_USERNAME = '@user';
+
+export function sanitizeTelegramUsername(raw?: string | null){
+  if (typeof raw !== 'string') return DEFAULT_USERNAME;
+  const trimmed = raw.trim();
+  if (!trimmed) return DEFAULT_USERNAME;
+  const withoutAt = trimmed.startsWith('@') ? trimmed.slice(1) : trimmed;
+  const cleaned = withoutAt.replace(/[^a-zA-Z0-9_]/g, '');
+  if (!cleaned) return DEFAULT_USERNAME;
+  return `@${cleaned}`;
+}


### PR DESCRIPTION
## Summary
- replace the placeholder i18n provider with a locale-aware implementation that loads dictionaries, persists the active language, and exposes a shared `t` helper
- reshape locale dictionaries and re-export them through `components/providers/I18nProvider` for reuse across the app
- translate key screens (home, profile, security, top-up, KYC, language settings, quick actions) to pull strings from the shared dictionaries

## Testing
- `npm run lint` *(fails: interactive Next.js lint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a04e7a408326859c52755389d309