### PR TITLE
Support namespace-aware translations

### DIFF
--- a/app/settings/language/page.v2.tsx
+++ b/app/settings/language/page.v2.tsx
@@ -12,7 +12,7 @@ export default function LanguagePage() {
   const { lang, setLang, t } = useI18n();
   return (
     <main className="mx-auto max-w-[480px] p-4">
-      <h1 className="text-xl font-semibold mb-4">{t('settings.language.title')}</h1>
+      <h1 className="text-xl font-semibold mb-4">{t('settings', 'language_title')}</h1>
       <div className="space-y-2">
         {LANGS.map(L => (
           <button


### PR DESCRIPTION
## Summary
- implement dictionary-backed translations that can compose namespace and key segments before lookup
- update the settings language page to call the translator with the namespace helper signature

## Testing
- npm run build *(fails: missing components referenced during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_68d5af5ea3d48326871c0ca0658a5a44